### PR TITLE
Update sparse.py: tiny typo in documentation

### DIFF
--- a/torch/nn/modules/sparse.py
+++ b/torch/nn/modules/sparse.py
@@ -230,9 +230,9 @@ class EmbeddingBag(Module):
     For bags of constant length, no :attr:`per_sample_weights`, no indices equal to :attr:`padding_idx`,
     and with 2D inputs, this class
 
-        * with ``mode="sum"`` is equivalent to :class:`~torch.nn.Embedding` followed by ``torch.sum(dim=1)``,
-        * with ``mode="mean"`` is equivalent to :class:`~torch.nn.Embedding` followed by ``torch.mean(dim=1)``,
-        * with ``mode="max"`` is equivalent to :class:`~torch.nn.Embedding` followed by ``torch.max(dim=1)``.
+        * with ``mode="sum"`` is equivalent to :class:`~torch.nn.Embedding` followed by ``torch.sum(dim=0)``,
+        * with ``mode="mean"`` is equivalent to :class:`~torch.nn.Embedding` followed by ``torch.mean(dim=0)``,
+        * with ``mode="max"`` is equivalent to :class:`~torch.nn.Embedding` followed by ``torch.max(dim=0)``.
 
     However, :class:`~torch.nn.EmbeddingBag` is much more time and memory efficient than using a chain of these
     operations.


### PR DESCRIPTION
It is a tiny misleading typo in documentation.
Just to be perfect project.

Fixes #ISSUE_NUMBER
